### PR TITLE
Issue #136: FAPI labels and formatting

### DIFF
--- a/config/staging/views.view.form_api.json
+++ b/config/staging/views.view.form_api.json
@@ -1534,7 +1534,7 @@
                         "ui_name": "",
                         "label": "Heading",
                         "empty": 0,
-                        "content": "<h2 id=\"default-values\">Default values</h2>\r\n<p>Every element automatically has these default values (see system_element_info()):</p>\r\n<ul>\r\n  <li><a href=\"#description\">#description</a> = NULL</li>\r\n  <li><a href=\"#attributes\">#attributes</a> = array()</li>\r\n  <li><a href=\"#required\">#required</a> = FALSE</li>\r\n  <li><a href=\"#tree\">#tree</a> = FALSE</li>\r\n  <li><a href=\"#parents\">#parents</a> = array()</li>\r\n</ul>\r\n<p>The following is a list of default values which do not need to be set (found in system_element_info):</p>",
+                        "content": "<h2 id=\"default-values\">Default values</h2>\r\n<p>Every element automatically has these default values (see system_element_info()):</p>\r\n<ul>\r\n  <li><a href=\"#description\">#description</a> = NULL</li>\r\n  <li><a href=\"#attributes\">#attributes</a> = array()</li>\r\n  <li><a href=\"#required\">#required</a> = FALSE</li>\r\n  <li><a href=\"#tree\">#tree</a> = FALSE</li>\r\n  <li><a href=\"#parents\">#parents</a> = array()</li>\r\n</ul>\r\n<p>The following is a list of default values which do not need to be set (found in system_element_info()):</p>",
                         "format": "fix_html",
                         "tokenize": 0
                     }

--- a/www/modules/custom/backdropapi/backdropapi.module
+++ b/www/modules/custom/backdropapi/backdropapi.module
@@ -84,19 +84,20 @@ function backdropapi_form_api_table() {
   }
 
   // Theme the tables.
+  $heading_elements = '<h3 id="input-elements">' . t('Input elements') . '</h3>';
   $table_elements = theme('table', array(
     'header' => $header_elements,
     'rows' => $rows_elements,
     'attributes' => array('class' => array('form-api')),
   ));
-  $heading_special = '<h3 id="special-elements">' . t('Special elements') . '</h3>';
+  $heading_special = '<h3 id="special-elements">' . t('Structure elements') . '</h3>';
   $table_special = theme('table', array(
     'header' => $header_special,
     'rows' => $rows_special,
     'attributes' => array('class' => array('form-api')),
   ));
 
-  return $table_elements . $heading_special . $table_special;
+  return $heading_elements . $table_elements . $heading_special . $table_special;
 }
 
 /**

--- a/www/themes/api_borg/css/page-form-api.css
+++ b/www/themes/api_borg/css/page-form-api.css
@@ -99,3 +99,11 @@ p {
 .form_api .l-bottom-inner > .row {
   display: block;
 }
+
+/* Tightening up the lists in Default values */
+.view-display-id-attachment_3 .view-header li {
+  margin: 0 0 0.25em 0;
+}
+.view-display-id-attachment_3 .views-field-field-fapi-property {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/docs.backdropcms.org/issues/136.

Also: 
* Tighten up listings of default properties using CSS.
* Add () to system_element_info so that it gets hyperlinked.