### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository holds the codebase for
 ## Issues
 
 This project contains an
-[issue tracker](https://github.com/backdrop-ops/dcos.backdropcms.org/issues)
+[issue tracker](https://github.com/backdrop-ops/docs.backdropcms.org/issues)
 specifically for docs.backdropcms.org. Please use this issue tracker when:
 * filing bug reports
 * requesting new features


### PR DESCRIPTION
The README.md which was containing a typo in the issue URL is now fixed. 
Fixes https://github.com/backdrop-ops/docs.backdropcms.org/issues/186.